### PR TITLE
Ghost MechJeb2 installation fix for Windows GUI

### DIFF
--- a/NetKAN/MechJeb2-dev.netkan
+++ b/NetKAN/MechJeb2-dev.netkan
@@ -9,10 +9,6 @@
     "license"      : "GPL-3.0",
     "x_ci_version_base" : "2.5.1.0",
 
-    "provides" : [
-        "MechJeb2"
-    ],
-
     "conflicts" : [
         { "name" : "MechJeb2" }
     ],


### PR DESCRIPTION
This way CKAN shall no longer give an option for upgrading nonexistent MechJeb2-release version when MechJeb2-dev is installed.
(the issue was noticed on Windows GUI)
