### PR TITLE
Fixing an obsolete thing...

### DIFF
--- a/NetKAN/MechJeb2-dev.netkan
+++ b/NetKAN/MechJeb2-dev.netkan
@@ -7,7 +7,7 @@
     "abstract"     : "Anatid Robotics and Multiversal Mechatronics proudly presents the first flight assistant autopilot: MechJeb",
     "author"       : "sarbian",
     "license"      : "GPL-3.0",
-    "x_ci_version_base" : "2.5.4.0",
+    "x_ci_version_base" : "2.5.5.0",
 
     "provides" : [
         "MechJeb2"


### PR DESCRIPTION
which noone uses to keep @Dazpoet happy for the next time he wants to do a https://github.com/KSP-CKAN/CKAN-meta-dev/pull/7

I noticed 2.5.5 is still so new it doesn't have dev-releases but I'm sure they'll come so fixing this allows all the users still handling dev-releases of MJ2 through CKAN by manually fixing them when needed (me, myself and I) to keep doing so without manually setting a new x_ci_version_base each time they download this file.
