### PR TITLE
Fixing this file again...

### DIFF
--- a/NetKAN/MechJeb2-dev.netkan
+++ b/NetKAN/MechJeb2-dev.netkan
@@ -1,31 +1,28 @@
 {
-    "spec_version" : "v1.6",
-    "identifier"   : "MechJeb2-dev",
-    "ksp_version"  : "1.0",
-    "$kref"        : "#/ckan/jenkins/MechJeb2",
-    "name"         : "MechJeb 2 - DEV RELEASE",
-    "abstract"     : "Anatid Robotics and Multiversal Mechatronics proudly presents the first flight assistant autopilot: MechJeb",
-    "author"       : "sarbian",
-    "license"      : "GPL-3.0",
-    "x_ci_version_base" : "2.5.5.0",
-
-    "provides" : [
-        "MechJeb2"
-    ],
-
+    "identifier" : "MechJeb2-dev",
+	"provides" : [ "MechJeb2" ],
+	"ksp_version" : "1.2",
+	"name" : "MechJeb2 - DEV RELEASE",
+	"abstract"     : "Development release of MechJeb2, use at your own risk",
+	"author": "Sarbian",
+    "resources": {
+        "homepage"  : "http://forum.kerbalspaceprogram.com/threads/124336",
+        "repository": "https://github.com/MuMech/MechJeb2/"
+    },
+	"license" : "GPL-3.0",
     "conflicts" : [
         { "name" : "MechJeb2" }
     ],
-
-    "install": [
+	"$kref": "#/ckan/jenkins/https://ksp.sarbian.com/jenkins/job/MechJeb2-Dev/",
+	"spec_version" : "v1.16",
+    "x_netkan_jenkins": {
+        "use_filename_version": true
+    },
+    "x_netkan_version_edit": "^MechJeb2-(?<version>\\d+\\.\\d+\\.\\d+\\.\\d+\\-\\d+\\d+\\d+)\\.zip$",
+	"install": [
         {
             "find": "MechJeb2",
             "install_to": "GameData"
         }
-    ],
-    "resources": {
-        "ci"        : "https://ksp.sarbian.com/jenkins/job/MechJeb2-Dev/",
-        "homepage"  : "http://forum.kerbalspaceprogram.com/threads/124336",
-        "repository": "https://github.com/MuMech/MechJeb2/"
-    }
+    ]
 }


### PR DESCRIPTION
...because I need my MJ2-dev and can't live with installing mods manually anymore. This time more things had changed than last so I'm hoping I got everything right this time, it does generate a valid .ckan file when running it locally.

Is it not possible to put files like these directly into the NetKAN repository nowadays with bots running and stuff? I noticed that we already have [Amazing Curve Editor](https://github.com/KSP-CKAN/NetKAN/blob/ada4f8324490724f517801fdd0bf2432612cf9bf/NetKAN/AmazingCurveEditor.netkan) in the main directory so I assume that Jenkins $kref's aren't as buggy as I recall them once being? paging @techman83 for that, assuming he's still the one to ask such things.

 However I do realize adding dev-releases of mods into primary NetKAN directory might be a path we don't want to go down? And I'm not sure @Sarbian[ would like it either](https://github.com/KSP-CKAN/CKAN/blob/master/policy/Opt-out-list.md), hence me not making a PR to that effect but rather putting it here in the dead and long forgotten place where only I will use it :)
