### PR TITLE
Mark repository as retired

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-NetKAN-dev
-==========
+## This repository is retired
 
-Metadata files used by the NetKAN/CKAN indexer (Development versions)
+These files contain metadata for pre-releases of mods, but they have not been updated in 5+ years and are no longer useful.
+
+See [KSP-CKAN/NetKAN-Infra#155](https://github.com/KSP-CKAN/NetKAN-Infra/issues/155) for details.


### PR DESCRIPTION
See KSP-CKAN/NetKAN-Infra#155; this change marks the README on the master branch as retired.